### PR TITLE
fix: Various fixes identified when migrating status-desktop

### DIFF
--- a/src/nimqml/private/dotherside.nim
+++ b/src/nimqml/private/dotherside.nim
@@ -1,6 +1,10 @@
 {.push raises: [].}
 
 import tables, seaqt/QtCore/qtcore_pkg
+import seaqt/QtQml/gen_qjsengine
+# QObject ownership lives on QJSEngine in Qt 6 but on QQmlEngine in Qt 5; import
+# both so setCppOwnership can pick whichever the active Qt version provides.
+import seaqt/QtQml/gen_qqmlengine
 
 type
   NimQObject = pointer
@@ -142,8 +146,10 @@ proc dos_qapplication_delete() =
   delete(move(qapp))
 
 # QGuiApplication
+var qgapp: gen_qguiapplication.QGuiApplication
+
 proc dos_qguiapplication_create() =
-  debugEcho "dos_qguiapplication_create() "
+  qgapp = gen_qguiapplication.QGuiApplication.create()
 
 proc dos_qguiapplication_exec() =
   discard gen_qguiapplication.QGuiApplication.exec()
@@ -152,7 +158,7 @@ proc dos_qguiapplication_quit() =
   gen_qcoreapplication.QCoreApplication.quit()
 
 proc dos_qguiapplication_delete() =
-  debugEcho "dos_qguiapplication_delete() "
+  delete(move(qgapp))
 
 # QQmlContext
 proc dos_qqmlcontext_setcontextproperty(
@@ -280,13 +286,23 @@ proc dos_qobject_qmetaobject(): DosQMetaObject =
     addr slotDefs,
     addr propDefs,
   )
+proc setCppOwnership(obj: gen_qobject.QObject) =
+  ## This static method is on QJSEngine in Qt 6 and on QQmlEngine in Qt 5;
+  const CppOwnership = 0.cint
+  when compiles(gen_qjsengine.QJSEngine.setObjectOwnership(obj, CppOwnership)):
+    gen_qjsengine.QJSEngine.setObjectOwnership(obj, CppOwnership)
+  else:
+    gen_qqmlengine.QQmlEngine.setObjectOwnership(obj, CppOwnership)
+
 proc dos_qobject_create(nimobject: NimQObject, metaObject: DosQMetaObject, dosQObjectCallback: DosQObjectCallBack): DosQObject =
   let vtbl = new QObjectVtable
   gen_qobject.QObject.setupCallbacks(
     nimobject, metaObject, dosQObjectCallback, vtbl[], QObjectmetacall
   )
 
-  gen_qobject.QObject.create(vtbl = vtbl).take()
+  let obj = gen_qobject.QObject.create(vtbl = vtbl)
+  setCppOwnership(obj)
+  obj.take()
 
 proc dos_qobject_objectName(qobject: DosQObject): cstring =
   debugEcho "dos_qobject_objectName(qobject: DosQObject): cstring "
@@ -294,17 +310,21 @@ proc dos_qobject_objectName(qobject: DosQObject): cstring =
 proc dos_qobject_setObjectName(qobject: DosQObject, name: cstring) =
   qobject.setObjectName($name)
 proc dos_qobject_signal_emit(qobject: DosQObject, signalName: cstring, argumentsCount: cint, arguments: ptr DosQVariantArray) =
+  if cast[pointer](qobject).isNil:
+    return
+
   let mo = qobject.metaObject()
+  if mo.h.isNil:
+    return
 
   for i in 0 ..< mo.methodCount:
     let meth = mo.methodX(cint(i))
     if meth.parameterCount() == argumentsCount and signalName.toOpenArrayByte(0, len(signalName) - 1) == meth.name:
-
       var argv = newSeq[pointer](argumentsCount + 1)
-      for i in 0 ..< argumentsCount:
-        argv[i + 1] = arguments[i].constData()
+      for j in 0 ..< argumentsCount:
+        argv[j + 1] = arguments[j].constData()
       gen_qobjectdefs.QMetaObject.activate(qobject, cint i, addr argv[0])
-      break
+      return
 
 proc dos_qobject_connect_static(
     sender: DosQObject,
@@ -473,7 +493,9 @@ proc dos_qabstractitemmodel_create(modelPtr: NimQAbstractItemModel,
     modelPtr, qaimCallbacks, vtbl[]
   )
 
-  gen_qabstractitemmodel.QAbstractItemModel.create(vtbl).take()
+  let model = gen_qabstractitemmodel.QAbstractItemModel.create(vtbl)
+  setCppOwnership(gen_qobject.QObject(h: model.h, owned: false))
+  model.take()
 
 proc dos_qabstractitemmodel_beginInsertRows(model: DosQAbstractItemModel,
                                             parentIndex: DosQModelIndex,
@@ -492,6 +514,17 @@ proc dos_qabstractitemmodel_beginRemoveRows(model: DosQAbstractItemModel,
 
 proc dos_qabstractitemmodel_endRemoveRows(model: DosQAbstractItemModel) =
   model.endRemoveRows()
+
+proc dos_qabstractitemmodel_beginMoveRows(model: DosQAbstractItemModel,
+                                          sourceParent: DosQModelIndex,
+                                          sourceFirst: cint,
+                                          sourceLast: cint,
+                                          destParent: DosQModelIndex,
+                                          destChild: cint) =
+  discard model.beginMoveRows(sourceParent, sourceFirst, sourceLast, destParent, destChild)
+
+proc dos_qabstractitemmodel_endMoveRows(model: DosQAbstractItemModel) =
+  model.endMoveRows()
 
 proc dos_qabstractitemmodel_beginInsertColumns(model: DosQAbstractItemModel,
                                                parentIndex: DosQModelIndex,
@@ -576,7 +609,9 @@ proc dos_qabstractlistmodel_create(modelPtr: NimQAbstractListModel,
     modelPtr, qaimCallbacks, vtbl[]
   )
 
-  gen_qabstractitemmodel.QAbstractListModel.create(vtbl = vtbl).take()
+  let model = gen_qabstractitemmodel.QAbstractListModel.create(vtbl = vtbl)
+  setCppOwnership(gen_qobject.QObject(h: model.h, owned: false))
+  model.take()
 
 proc dos_qabstractlistmodel_columnCount(modelPtr: DosQAbstractListModel, index: DosQModelIndex): cint =
   if index.isValid(): 1 else: 0
@@ -613,7 +648,9 @@ proc dos_qabstracttablemodel_create(modelPtr: NimQAbstractTableModel,
     modelPtr, qaimCallbacks, vtbl[]
   )
 
-  gen_qabstractitemmodel.QAbstractTableModel.create(vtbl = vtbl).take()
+  let model = gen_qabstractitemmodel.QAbstractTableModel.create(vtbl = vtbl)
+  setCppOwnership(gen_qobject.QObject(h: model.h, owned: false))
+  model.take()
 
 proc dos_qabstracttablemodel_parent(modelPtr: DosQAbstractTableModel, index: DosQModelIndex): DosQModelIndex =
   QModelIndex.create().take()

--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -189,6 +189,19 @@ proc endRemoveRows*(self: QAbstractItemModel) =
   debugMsg("QAbstractItemModel", "endRemoveRows")
   dos_qabstractitemmodel_endRemoveRows(self.vptr.DosQAbstractItemModel)
 
+proc beginMoveRows*(self: QAbstractItemModel, sourceParentIndex: QModelIndex,
+    sourceFirst: int, sourceLast: int, destParentIndex: QModelIndex, destinationChild: int) =
+  ## Notify the view that the model is about to move rows
+  debugMsg("QAbstractItemModel", "beginMoveRows")
+  dos_qabstractitemmodel_beginMoveRows(self.vptr.DosQAbstractItemModel,
+    sourceParentIndex.vptr, sourceFirst.cint, sourceLast.cint,
+    destParentIndex.vptr, destinationChild.cint)
+
+proc endMoveRows*(self: QAbstractItemModel) =
+  ## Notify the view that the rows have been moved
+  debugMsg("QAbstractItemModel", "endMoveRows")
+  dos_qabstractitemmodel_endMoveRows(self.vptr.DosQAbstractItemModel)
+
 proc beginInsertColumns*(self: QAbstractItemModel, parentIndex: QModelIndex, first: int, last: int) =
   ## Notify the view that the model is about to inserting the given number of columns
   debugMsg("QAbstractItemModel", "beginInsertColumns")
@@ -222,11 +235,15 @@ proc endResetModel*(self: QAbstractItemModel) =
 proc dataChanged*(self: QAbstractItemModel,
                  topLeft: QModelIndex,
                  bottomRight: QModelIndex,
-                 roles: openArray[int]) =
-  ## Notify the view that the model data changed
+                 roles: openArray[int] = []) =
+  ## Notify the view that the model data changed.
   debugMsg("QAbstractItemModel", "dataChanged")
-  var copy: seq[cint]
-  for i in roles:
-    copy.add(i.cint)
-  dos_qabstractitemmodel_dataChanged(self.vptr.DosQAbstractItemModel, topLeft.vptr,
-                                     bottomRight.vptr, copy[0].addr, copy.len.cint)
+  if roles.len == 0:
+    dos_qabstractitemmodel_dataChanged(self.vptr.DosQAbstractItemModel, topLeft.vptr,
+                                       bottomRight.vptr, nil, 0)
+  else:
+    var copy: seq[cint]
+    for i in roles:
+      copy.add(i.cint)
+    dos_qabstractitemmodel_dataChanged(self.vptr.DosQAbstractItemModel, topLeft.vptr,
+                                       bottomRight.vptr, copy[0].addr, copy.len.cint)

--- a/src/nimqml/private/qmetaobject.nim
+++ b/src/nimqml/private/qmetaobject.nim
@@ -53,9 +53,9 @@ proc setup(superClass: QMetaObject,
                                             notifySignal: notifySignal)
     dosProperties.add(dosProperty)
 
-  let signals = DosSignalDefinitions(count: dosSignals.len.cint, definitions: if dosSignals.len > 0: dosSignals[0].unsafeAddr else: nil)
-  let slots = DosSlotDefinitions(count: dosSlots.len.cint, definitions: if dosSlots.len > 0: dosSlots[0].unsafeAddr else: nil)
-  let properties = DosPropertyDefinitions(count: dosProperties.len.cint, definitions: if dosProperties.len > 0: dosProperties[0].unsafeAddr else: nil)
+  let signalsList = DosSignalDefinitions(count: dosSignals.len.cint, definitions: if dosSignals.len > 0: dosSignals[0].unsafeAddr else: nil)
+  let slotsList = DosSlotDefinitions(count: dosSlots.len.cint, definitions: if dosSlots.len > 0: dosSlots[0].unsafeAddr else: nil)
+  let propertiesList = DosPropertyDefinitions(count: dosProperties.len.cint, definitions: if dosProperties.len > 0: dosProperties[0].unsafeAddr else: nil)
 
   when compiles(GC_ref(dosSignalParameters)):
     # prevent garbage collector from reclaiming parameter defs in case these
@@ -64,15 +64,24 @@ proc setup(superClass: QMetaObject,
     # internal pointers are not accounted for / dropped by the C compiler
     GC_ref(dosSignalParameters)
     GC_ref(dosSlotParameters)
+    GC_ref(dosSignals)
     GC_ref(dosSlots)
     GC_ref(dosProperties)
 
-  result = dos_qmetaobject_create(superClass.vptr, className.cstring, signals.unsafeAddr, slots.unsafeAddr, properties.unsafeAddr)
+    GC_ref(signals)
+    GC_ref(slots)
+    GC_ref(properties)
+
+  result = dos_qmetaobject_create(superClass.vptr, className.cstring, signalsList.unsafeAddr, slotsList.unsafeAddr, propertiesList.unsafeAddr)
   when compiles(GC_unref(dosSignalParameters)):
     GC_unref(dosSignalParameters)
     GC_unref(dosSlotParameters)
+    GC_unref(dosSignals)
     GC_unref(dosSlots)
     GC_unref(dosProperties)
+    GC_unref(signals)
+    GC_unref(slots)
+    GC_unref(properties)
 
 proc invokeMethod*(typ: type QMetaObject, context: QObject, l: LambdaInvokerProc, connectionType: ConnectionType = ConnectionType.AutoConnection): bool =
   let id = LambdaInvoker.instance.add(l)

--- a/src/nimqml/private/qobject.nim
+++ b/src/nimqml/private/qobject.nim
@@ -148,6 +148,12 @@ proc deleteLater*(self: QObject) =
   dos_qobject_deleteLater(self.vptr)
   self.vptr.resetToNil
 
-proc objectNameChanged*(self: QObject, objectName: string) {.signal.} = 
+proc objectNameChanged*(self: QObject, objectName: string) {.signal.} =
   ## Emit the object name changed signal
   self.emit("objectNameChanged", [newQVariant(objectName)])
+
+proc vptr*(self: QObject): pointer =
+  cast[pointer](self.vptr)
+
+proc `vptr=`*(self: QObject, p: pointer) =
+  self.vptr = cast[DosQObject](p)

--- a/src/nimqml/private/qqmlapplicationengine.nim
+++ b/src/nimqml/private/qqmlapplicationengine.nim
@@ -23,6 +23,9 @@ proc setRootContextProperty*(self: QQmlApplicationEngine, name: string, value: Q
   let context = dos_qqmlapplicationengine_context(self.vptr)
   dos_qqmlcontext_setcontextproperty(context, name.cstring, value.vptr)
 
+proc vptr*(self: QQmlApplicationEngine): pointer =
+  cast[pointer](self.vptr)
+
 proc delete*(self: QQmlApplicationEngine) =
   ## Delete the given QQmlApplicationEngine
   debugMsg("QQmlApplicationEngine", "delete")

--- a/src/nimqml/private/qvariant.nim
+++ b/src/nimqml/private/qvariant.nim
@@ -123,3 +123,9 @@ proc `value=`*(self: QVariant, value: int) = self.intVal = value
 proc `value=`*(self: QVariant, value: bool) = self.boolVal = value
 proc `value=`*(self: QVariant, value: cfloat) = self.floatVal = value
 proc `value=`*(self: QVariant, value: cdouble) = self.doubleVal = value
+
+proc vptr*(self: QVariant): pointer =
+  cast[pointer](self.vptr)
+
+proc newQVariantTakingPtr*(p: pointer): QVariant =
+  newQVariant(cast[DosQVariant](p), Ownership.Take)


### PR DESCRIPTION
- cppOwnership: DOtherSide sets cppOwnership in all *_create methods
- signal/slot info collected before metaobject info registration under LTO
- missing begin/endMoveRows
- allow dataChangged signal emit with no roles (defaults to all)
- expose the`vptr`