### PR TITLE
fix: mark model wrappers as owner so delete() reaches the C++ side

### DIFF
--- a/src/nimqml/private/qabstractitemmodel.nim
+++ b/src/nimqml/private/qabstractitemmodel.nim
@@ -157,6 +157,7 @@ proc setup*(self: QAbstractItemModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
+  self.owner = true
   self.vptr = dos_qabstractitemmodel_create(addr(self[]), self.metaObject.vptr,
                                             qobjectCallback, qaimCallbacks).DosQObject
 

--- a/src/nimqml/private/qabstractlistmodel.nim
+++ b/src/nimqml/private/qabstractlistmodel.nim
@@ -31,6 +31,7 @@ proc setup*(self: QAbstractListModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
+  self.owner = true
   self.vptr = dos_qabstractlistmodel_create(addr(self[]), self.metaObject.vptr,
                                             qobjectCallback, qaimCallbacks).DosQObject
 

--- a/src/nimqml/private/qabstracttablemodel.nim
+++ b/src/nimqml/private/qabstracttablemodel.nim
@@ -31,6 +31,7 @@ proc setup*(self: QAbstractTableModel) =
   canFetchMore: canFetchMoreCallback,
   fetchMore: fetchMoreCallback)
 
+  self.owner = true
   self.vptr = dos_qabstracttablemodel_create(addr(self[]), self.metaObject.vptr,
                                             qobjectCallback, qaimCallbacks).DosQObject
 


### PR DESCRIPTION
QAbstractItemModel/QAbstractListModel/QAbstractTableModel setup assigned vptr but never set QObject.owner (only QObject.setup does), so delete() hit the 'not self.owner' guard and silently no-oped for every model. Dropping a Nim model then leaked its C++ object alive with a dangling Nim pointer, and any later consumer callback (view rowCount, roleNames) was a use-after-free - crashing e.g. status-desktop's send modal when a network switch dropped token-selector rows whose nested submodels QML still referenced.

With owner set, dropped models are genuinely deleted and Qt's destroyed() tracking lets QPointer/QML wrappers null out gracefully.